### PR TITLE
Take a stab at ci

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,0 +1,4 @@
+FROM rocker/r-devel
+USER docker
+RUN Rscript -e 'install.packages("Rcpp")'
+CMD "/bin/bash"

--- a/ci/buildAndTest.sh
+++ b/ci/buildAndTest.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# This script will be run within the Docker container to build and test.
+# TODO: how do we run the tests?
+R CMD INSTALL .

--- a/ci/withDocker.sh
+++ b/ci/withDocker.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+CI_DIR=$(cd "$(dirname "$0")"; pwd)
+PBBAMR_DIR=$(cd "$(dirname "$0")"/..; pwd)
+docker build -t pbbamr $CI_DIR
+docker run -h docker-host -v $PBBAMR_DIR:/pbbamr -w /pbbamr --rm=true  -i -t pbbamr $*

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,7 @@
+machine:
+  services:
+    - docker
+
+test:
+  override:
+    - ci/withDocker.sh ci/buildAndTest.sh


### PR DESCRIPTION
Taking a stab at ci.  

Building the docker is super slow, and it's a shame we have to build pbbam every time even though it will rarely be updated.  I'm also not happy that the rocker image isn't versioned.

These issues can all be addressed---we could use a cache directory to house ccache artifacts (speeding up pbbam build) and we could store our docker image on dockerhub or in the cache directory.  Optimizations.