### PR TITLE
Fix for integer data format

### DIFF
--- a/src/LoadData.cpp
+++ b/src/LoadData.cpp
@@ -344,10 +344,10 @@ DataFrame loadPBI(std::string filename,
       }
     }catch(...) {}
     df["ref"] = mappedtId;
-    df["tstart"] = mappedData.tStart_;
-    df["tend"] = mappedData.tEnd_;
-    df["astart"] = mappedData.aStart_;
-    df["aend"] = mappedData.aEnd_;
+    df["tstart"] = IntegerVector(mappedData.tStart_.begin(), mappedData.tStart_.end());
+    df["tend"] = IntegerVector(mappedData.tEnd_.begin(), mappedData.tEnd_.end());
+    df["astart"] = IntegerVector(mappedData.aStart_.begin(), mappedData.aStart_.end());
+    df["aend"] = IntegerVector(mappedData.aEnd_.begin(), mappedData.aEnd_.end());
     df["rc"] = LogicalVector(mappedData.revStrand_.begin(), mappedData.revStrand_.end());
     df["matches"] = mappedData.nM_;
     df["mismatches"] = mappedData.nMM_;

--- a/tests/testthat/test.load.R
+++ b/tests/testthat/test.load.R
@@ -4,6 +4,7 @@ library(pbbamr)
 #ofile = "/Users/nigel/git/pbbamr/tests/testthat/loadedAln.Rd"
 #sbamdset = "/Users/nigel/git/pbbamr/tests/testthat/SubreadSet/m54006_160504_020705.tiny.subreadset.xml"
 #setwd("/Users/nigel/git/pbbamr/tests/testthat/")
+#setwd("/Users/ytian/Documents/Git/pbbamr/tests/testthat/")
 bfile = "test.aligned.bam"
 ffile = "lambdaNEB.fa"
 ofile = "loadedAln.Rd"
@@ -88,3 +89,11 @@ test_that("FilteringWorks", {
   expect_true(min(index$rq) < 0.901)
 
   })
+
+test_that("IndexLoadAsInteger", {
+  d = loadPBI(bfile)
+  index <- c("tstart", "tend", "astart", "aend")
+  for (i in index) {
+    expect_equal(class(d[,i]), "integer")
+  }
+})


### PR DESCRIPTION
Data of unit format in C++ does not exist in R, R automatically
transfer it to numeric. To fix this issue, we define integer vectors in
R to make sure the tstart, tend, astart, and aend are read as integer
type. Talk with Derek who said these fields should have been ints
instead of uints to begin with so that they match the bam file
encoding, we might fix that later.