### PR TITLE
Avoid Seek on Sequential Access

### DIFF
--- a/src/htslib/hfile.c
+++ b/src/htslib/hfile.c
@@ -67,7 +67,8 @@ hFILE *hfile_init(size_t struct_size, const char *mode, size_t capacity)
 {
     hFILE *fp = (hFILE *) malloc(struct_size);
     if (fp == NULL) goto error;
-
+    // TODO: In the case that we are initializing a hFILE_mem, do we really
+    // need to allocate a buffer of this size to wrap the original memory buffer?
     if (capacity == 0) capacity = 32768;
     // FIXME For now, clamp input buffer sizes so mpileup doesn't eat memory
     if (strchr(mode, 'r') && capacity > 32768) capacity = 32768;
@@ -292,6 +293,81 @@ void hclose_abruptly(hFILE *fp)
 }
 
 
+/*********************
+* In-memory backend *
+*********************/
+
+typedef struct {
+  hFILE base;
+  const char *buffer;
+  int owns_mem:1;
+  size_t length, pos;
+} hFILE_mem;
+
+static ssize_t mem_read(hFILE *fpv, void *buffer, size_t nbytes)
+{
+  hFILE_mem *fp = (hFILE_mem *) fpv;
+  size_t avail = fp->length - fp->pos;
+  if (nbytes > avail) nbytes = avail;
+  memcpy(buffer, fp->buffer + fp->pos, nbytes);
+  fp->pos += nbytes;
+  return nbytes;
+}
+
+static off_t mem_seek(hFILE *fpv, off_t offset, int whence)
+{
+  hFILE_mem *fp = (hFILE_mem *) fpv;
+  size_t absoffset = (offset >= 0)? offset : -offset;
+  size_t origin;
+
+  switch (whence) {
+  case SEEK_SET: origin = 0; break;
+  case SEEK_CUR: origin = fp->pos; break;
+  case SEEK_END: origin = fp->length; break;
+  default: errno = EINVAL; return -1;
+  }
+
+  if ((offset  < 0 && absoffset > origin) ||
+      (offset >= 0 && absoffset > fp->length - origin)) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  fp->pos = origin + offset;
+  return fp->pos;
+}
+
+static int mem_close(hFILE *fpv)
+{
+  hFILE_mem *fp = (hFILE_mem *) fpv;
+  if (fp->owns_mem) {
+    free((void*)fp->buffer);
+  }
+  return 0;
+}
+
+static const struct hFILE_backend mem_backend =
+  {
+  mem_read, NULL, mem_seek, NULL, mem_close
+  };
+
+static hFILE *hopen_mem(const char *data, const char *mode, size_t len_data,
+                        int ownsMemory)
+{
+  // TODO Implement write modes, which will require memory allocation
+  if (strchr(mode, 'r') == NULL) { errno = EINVAL; return NULL; }
+  hFILE_mem *fp = (hFILE_mem *) hfile_init(sizeof (hFILE_mem), mode, len_data);
+  if (fp == NULL) return NULL;
+
+  fp->buffer = data;
+  fp->length = len_data;
+  fp->pos = 0;
+  fp->base.backend = &mem_backend;
+  fp->owns_mem = ownsMemory;
+  return &fp->base;
+}
+
+
 /***************************
  * File descriptor backend *
  ***************************/
@@ -400,14 +476,30 @@ static hFILE *hopen_fd(const char *filename, const char *mode)
     hFILE_fd *fp = NULL;
     int fd = open(filename, hfile_oflags(mode), 0666);
     if (fd < 0) goto error;
+    off_t currentPos = lseek(fd, (size_t)0, SEEK_CUR);
+    // Get the file size
+    off_t fileSize = lseek(fd, (size_t)0, SEEK_END);
+    // Seek back to the begining of file
+    lseek(fd, currentPos, SEEK_SET);
 
-    fp = (hFILE_fd *) hfile_init(sizeof (hFILE_fd), mode, blksize(fd));
-    if (fp == NULL) goto error;
-
-    fp->fd = fd;
-    fp->is_socket = 0;
-    fp->base.backend = &fd_backend;
-    return &fp->base;
+    // For small files that are in rb mode,
+    // we are just going to load them into memory to avoid
+    // repeatedly fetching the same data from disk.
+    if ((fileSize < (1 << 17)) &&
+        strcmp(mode, "rb") == 0) {
+        char* buffer = malloc(fileSize);
+        ssize_t n = read(fd, buffer, fileSize);
+        if (n < 0) goto error;
+        close(fd);
+        return hopen_mem(buffer, mode, fileSize, 1);
+    } else {
+        fp = (hFILE_fd *) hfile_init(sizeof (hFILE_fd), mode, blksize(fd));
+        if (fp == NULL) goto error;
+        fp->fd = fd;
+        fp->is_socket = 0;
+        fp->base.backend = &fd_backend;
+        return &fp->base;
+    }
 
 error:
     if (fd >= 0) { int save = errno; (void) close(fd); errno = save; }
@@ -454,74 +546,6 @@ int hfile_oflags(const char *mode)
 }
 
 
-/*********************
- * In-memory backend *
- *********************/
-
-typedef struct {
-    hFILE base;
-    const char *buffer;
-    size_t length, pos;
-} hFILE_mem;
-
-static ssize_t mem_read(hFILE *fpv, void *buffer, size_t nbytes)
-{
-    hFILE_mem *fp = (hFILE_mem *) fpv;
-    size_t avail = fp->length - fp->pos;
-    if (nbytes > avail) nbytes = avail;
-    memcpy(buffer, fp->buffer + fp->pos, nbytes);
-    fp->pos += nbytes;
-    return nbytes;
-}
-
-static off_t mem_seek(hFILE *fpv, off_t offset, int whence)
-{
-    hFILE_mem *fp = (hFILE_mem *) fpv;
-    size_t absoffset = (offset >= 0)? offset : -offset;
-    size_t origin;
-
-    switch (whence) {
-    case SEEK_SET: origin = 0; break;
-    case SEEK_CUR: origin = fp->pos; break;
-    case SEEK_END: origin = fp->length; break;
-    default: errno = EINVAL; return -1;
-    }
-
-    if ((offset  < 0 && absoffset > origin) ||
-        (offset >= 0 && absoffset > fp->length - origin)) {
-        errno = EINVAL;
-        return -1;
-    }
-
-    fp->pos = origin + offset;
-    return fp->pos;
-}
-
-static int mem_close(hFILE *fpv)
-{
-    return 0;
-}
-
-static const struct hFILE_backend mem_backend =
-{
-    mem_read, NULL, mem_seek, NULL, mem_close
-};
-
-static hFILE *hopen_mem(const char *data, const char *mode)
-{
-    // TODO Implement write modes, which will require memory allocation
-    if (strchr(mode, 'r') == NULL) { errno = EINVAL; return NULL; }
-
-    hFILE_mem *fp = (hFILE_mem *) hfile_init(sizeof (hFILE_mem), mode, 0);
-    if (fp == NULL) return NULL;
-
-    fp->buffer = data;
-    fp->length = strlen(data);
-    fp->pos = 0;
-    fp->base.backend = &mem_backend;
-    return &fp->base;
-}
-
 
 /******************************
  * hopen() backend dispatcher *
@@ -531,7 +555,7 @@ hFILE *hopen(const char *fname, const char *mode)
 {
     if (strncmp(fname, "http://", 7) == 0 ||
         strncmp(fname, "ftp://", 6) == 0) return hopen_net(fname, mode);
-    else if (strncmp(fname, "data:", 5) == 0) return hopen_mem(fname + 5, mode);
+    else if (strncmp(fname, "data:", 5) == 0) return hopen_mem(fname + 5, mode, strlen(fname + 5), 0); // Data must be text for length to be correctly specified
     else if (strcmp(fname, "-") == 0) return hopen_fd_stdinout(mode);
     else return hopen_fd(fname, mode);
 }

--- a/src/htslib/hfile.c
+++ b/src/htslib/hfile.c
@@ -481,12 +481,14 @@ static hFILE *hopen_fd(const char *filename, const char *mode)
     off_t fileSize = lseek(fd, (size_t)0, SEEK_END);
     // Seek back to the begining of file
     lseek(fd, currentPos, SEEK_SET);
-
-    // For small files that are in rb mode,
+    size_t lenstr = strlen(filename);
+    // For small files that are not indexes and given rb mode,
     // we are just going to load them into memory to avoid
     // repeatedly fetching the same data from disk.
     if ((fileSize < (1 << 17)) &&
-        strcmp(mode, "rb") == 0) {
+        strcmp(mode, "rb") == 0 &&
+        lenstr > 4 &&
+        (strcmp(filename + lenstr - 4, ".pbi") != 0 && strcmp(filename + lenstr - 4, ".bai") != 0) ) {
         char* buffer = malloc(fileSize);
         ssize_t n = read(fd, buffer, fileSize);
         if (n < 0) goto error;


### PR DESCRIPTION
Often times users will parse files asking for a read at a particular
offset, followed by a call that asks for the next read at a particular
offset.  In the generic case, the buffer is flushed and reloaded with
subsequent system calls on each write.  This change adjust the code so
that if we are already at the correct position to load the next data,
we just go ahead and do that.