### PR TITLE
More Robust Handling of Common Errors / Optimization

### DIFF
--- a/src/LoadData.cpp
+++ b/src/LoadData.cpp
@@ -28,6 +28,14 @@ bool FileExists(const std::string& path)
   return ifile.good();
 }
 
+// Utility function for String.EndsWith
+bool has_suffix(const std::string &str, const std::string &suffix)
+{
+  return str.size() >= suffix.size() &&
+    str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0;
+}
+
+
 // Some globals
 template<typename T>
 class CachedReader {
@@ -39,6 +47,8 @@ public:
     if (!reader || (fName != cached_name)) {
       if(!FileExists(fName)) {
         stop("File does not exist or is not readable.");
+      } else if (has_suffix(fName, ".xml")) {
+        stop("File should be the actual file and not an XML dataset.");
       }
       reader.reset(new T(fName));
       cached_name = fName;
@@ -271,12 +281,6 @@ List loadHeader(std::string filename) {
   return df;
 }
 
-// Utility function for String.EndsWith
-bool has_suffix(const std::string &str, const std::string &suffix)
-{
-  return str.size() >= suffix.size() &&
-    str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0;
-}
 
 // Get a mechanism to subset data frames in R using the R side function.
 // See: http://stackoverflow.com/questions/22828361/rcpp-function-to-select-and-to-return-a-sub-dataframe

--- a/src/LoadData.cpp
+++ b/src/LoadData.cpp
@@ -784,8 +784,9 @@ List loadHMMfromBAM(CharacterVector offsets,
       return NULL;
     }
 
-    IndexedFastaReader fasta(indexedFastaName);
-    BamReader reader(bamName);
+    IndexedFastaReader& fasta = *CachedFastaReader.GetReader(indexedFastaName);
+    BamReader& reader = *CachedBamReader.GetReader(bamName);
+
 
     // Always get reads in native orientation.
     auto orientation = Orientation::NATIVE;
@@ -934,8 +935,9 @@ List loadSingleZmwHMMfromBAM(CharacterVector offsets,
       return NULL;
     }
 
-    IndexedFastaReader fasta(indexedFastaName);
-    BamReader reader(bamName);
+    IndexedFastaReader& fasta = *CachedFastaReader.GetReader(indexedFastaName);
+    BamReader& reader = *CachedBamReader.GetReader(bamName);
+
 
     // Always get reads in native orientation.
     auto orientation = Orientation::NATIVE;

--- a/src/pbbam/IndexedFastaReader.cpp
+++ b/src/pbbam/IndexedFastaReader.cpp
@@ -54,7 +54,10 @@ namespace BAM {
 
 IndexedFastaReader::IndexedFastaReader(const std::string& filename)
 {
-    Open(filename);
+    bool okay = Open(filename);
+    if (!okay) {
+      throw std::runtime_error("Cannot open file " + filename);
+    }
 }
 
 IndexedFastaReader::IndexedFastaReader(const IndexedFastaReader& src)


### PR DESCRIPTION
A collection of two different improvements:

1 - We use a cached fasta and BAM reader for repeated queries.  This applies the speed improvements used for loading raw alignments to the functions that load training data for the HMM model fitting.

2 - Handle error cases where the user passes in an XML ReferenceSet/DataSet instead of a Fasta/BAM.  Previously this led to a segfault, but now we have two changes that handle this both in the core pbbam library and also in Rcpp by providing a more specific error message for XML files.

For review by @dalexander and @tian52 